### PR TITLE
Fixes bug cause by pressing the enter key while a checkbox in the treeview of step two

### DIFF
--- a/public/aria-tree.js
+++ b/public/aria-tree.js
@@ -420,6 +420,7 @@ Treeitem.prototype.handleKeydown = function (event) {
         defined near the bottom of this file */
         // tgt.dispatchEvent(clickEvent);
         if ($(document.activeElement).is('input:checkbox')) {
+          flag = true;
           break;
         }
         cycleSelect($(tgt));


### PR DESCRIPTION
issue persists for checkboxes in step 1, requires further investigation.